### PR TITLE
Remove obsolete SetupDefaultIntreactions

### DIFF
--- a/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/Controllers/WindowsMixedRealityController.cs
+++ b/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/Controllers/WindowsMixedRealityController.cs
@@ -55,12 +55,6 @@ namespace XRTK.WindowsMixedReality.Controllers
         /// <inheritdoc />
         public override MixedRealityInteractionMapping[] DefaultRightHandedInteractions => DefaultInteractions;
 
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(DefaultInteractions);
-        }
-
 #if UNITY_WSA
 
         /// <summary>


### PR DESCRIPTION
## Overview

Removes the obsolete `SetupDefaultInteractions` in `BaseController` since it's not run anywhere anymore.