### PR TITLE
Move platform profiles from SDK to WMR package

### DIFF
--- a/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/Profiles~/Contollers/WindowsMixedRealityControllerDataProviderProfile.asset
+++ b/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/Profiles~/Contollers/WindowsMixedRealityControllerDataProviderProfile.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe9eeb08f95b1c1419ad17953d9a48ee, type: 3}
+  m_Name: WMRControllerDataProviderProfile
+  m_EditorClassIdentifier: 
+  hasSetupDefaults: 1
+  controllerMappingProfiles:
+  - {fileID: 11400000, guid: aaa9b82b55ce7834bb43c9d726ff893e, type: 2}
+  - {fileID: 11400000, guid: 752ece58d1e10d4458ac9d6ad664cc58, type: 2}
+  - {fileID: 11400000, guid: 87a124892ea548a4ea4cbba488e06b5a, type: 2}
+  manipulationGestures: 0
+  navigationGestures: 0
+  useRailsNavigation: 0
+  railsNavigationGestures: 0
+  windowsGestureAutoStart: 0

--- a/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/Profiles~/Contollers/WindowsMixedRealityControllerDataProviderProfile.asset.meta
+++ b/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/Profiles~/Contollers/WindowsMixedRealityControllerDataProviderProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8e0139954c0b0ab41a6f5fce7c0594e1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/Profiles~/Contollers/WindowsMixedRealityHandControllerDataProviderProfile.asset
+++ b/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/Profiles~/Contollers/WindowsMixedRealityHandControllerDataProviderProfile.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29a54eda3f140e7418c5cb5c2bccd329, type: 3}
+  m_Name: WindowsMixedRealityHandControllerDataProviderProfile
+  m_EditorClassIdentifier: 
+  hasSetupDefaults: 1
+  controllerMappingProfiles:
+  - {fileID: 11400000, guid: b43ff1b6f37e65946b1abc7e50af105f, type: 2}
+  - {fileID: 11400000, guid: 6c775257f26873e459a492f28125e129, type: 2}
+  handMeshingEnabled: 0
+  handPhysicsEnabled: 0
+  useTriggers: 0
+  boundsMode: 0

--- a/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/Profiles~/Contollers/WindowsMixedRealityHandControllerDataProviderProfile.asset.meta
+++ b/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/Profiles~/Contollers/WindowsMixedRealityHandControllerDataProviderProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11ef7a331fa0a164bb9ac3e5cae510ff
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

WMR controller profiles were still living in SDK. Moved them to the WMR package
so they can be delivered when importing the WMR module.

## Changes

Moved default profiles.

## Submodule Changes

https://github.com/XRTK/SDK/pull/184