### PR TITLE
Update default near clip plane for transparent display

### DIFF
--- a/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/Profiles~/CameraSystem/WindowsMixedRealityCameraProviderProfile.asset
+++ b/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/Profiles~/CameraSystem/WindowsMixedRealityCameraProviderProfile.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   cameraClearFlagsOpaqueDisplay: 1
   backgroundColorOpaqueDisplay: {r: 0, g: 0, b: 0, a: 1}
   opaqueQualityLevel: 0
-  nearClipPlaneTransparentDisplay: 0.85
+  nearClipPlaneTransparentDisplay: 0.2
   cameraClearFlagsTransparentDisplay: 2
   backgroundColorTransparentDisplay: {r: 0, g: 0, b: 0, a: 0}
   transparentQualityLevel: 0


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Updates the WMR default near clip plane distance to 0.2 for transparent displays.
