### PR TITLE
Update WMR plugin package version to 1.0.21 and remove resolved workaround

### DIFF
--- a/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/Runtime/Providers/Controllers/WindowsMixedRealityMotionController.cs
+++ b/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/Runtime/Providers/Controllers/WindowsMixedRealityMotionController.cs
@@ -307,30 +307,7 @@ namespace XRTK.WindowsMixedReality.Providers.Controllers
                     interactionMapping.BoolData = interactionSourceState.grasped;
                     break;
                 case DeviceInputType.Select:
-                    bool selectPressed = interactionSourceState.selectPressed;
-
-                    // BEGIN WORKAROUND: Unity issue #1033526
-                    // See https://issuetracker.unity3d.com/issues/hololens-interactionsourcestate-dot-selectpressed-is-false-when-air-tap-and-hold
-                    // Bug was discovered May 2018 and still exists as of today Feb 2019 in version 2018.3.4f1, timeline for fix is unknown
-                    // The bug only affects the development workflow via Holographic Remoting or Simulation
-                    if (interactionSourceState.source.kind == InteractionSourceKind.Hand)
-                    {
-                        Debug.Assert(!(UnityEngine.XR.WSA.HolographicRemoting.ConnectionState == UnityEngine.XR.WSA.HolographicStreamerConnectionState.Connected
-                                       && interactionSourceState.selectPressed),
-                                     "Unity issue #1033526 seems to have been resolved. Please remove this ugly workaround!");
-
-                        // This workaround is safe as long as all these assumptions hold:
-                        Debug.Assert(!interactionSourceState.source.supportsGrasp);
-                        Debug.Assert(!interactionSourceState.source.supportsMenu);
-                        Debug.Assert(!interactionSourceState.source.supportsPointing);
-                        Debug.Assert(!interactionSourceState.source.supportsThumbstick);
-                        Debug.Assert(!interactionSourceState.source.supportsTouchpad);
-
-                        selectPressed = interactionSourceState.anyPressed;
-                    }
-                    // END WORKAROUND: Unity issue #1033526
-
-                    interactionMapping.BoolData = selectPressed;
+                    interactionMapping.BoolData = interactionSourceState.selectPressed;
                     break;
                 case DeviceInputType.Trigger:
                     interactionMapping.FloatData = interactionSourceState.selectPressedAmount;

--- a/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/package.json
+++ b/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/package.json
@@ -16,7 +16,7 @@
   "author": "XRTK Team (https://github.com/XRTK)",
   "dependencies": {
     "com.xrtk.core": "0.2.0-preview.34",
-    "com.unity.xr.windowsmr.metro": "1.0.19"
+    "com.unity.xr.windowsmr.metro": "1.0.21"
   },
   "profiles": [
     {


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Package changelog:
`Update remoting plugins to version 2.1.3.`

Removed workaround in `WindowsMixedRealityMotionController`.
Blocked until https://github.com/XRTK/XRTK-Core/pull/655 is merged in Core.


## Changes

- Updated the WMR XRTK package dependency
- Removed workaround that got resolved by the package update

## Breaking Changes

- Requires WMR package v.1.0.21 to be used
