### PR TITLE
WMR-Fix 2 - Ignore "unknown" handedness interaction sources on HL1

### DIFF
--- a/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/Runtime/Providers/Controllers/WindowsMixedRealityControllerDataProvider.cs
+++ b/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/Runtime/Providers/Controllers/WindowsMixedRealityControllerDataProvider.cs
@@ -409,8 +409,7 @@ namespace XRTK.WindowsMixedReality.Providers.Controllers
             switch (interactionSource.handedness)
             {
                 default:
-                    handedness = Handedness.None;
-                    break;
+                    return null;
                 case InteractionSourceHandedness.Left:
                     handedness = Handedness.Left;
                     break;


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

The HoloLens either prior to hand detection or on hand lost creates an InteractionState.handedness of type "unknown".

This update ignores any hands other than left or right on HL1. Tested with HL1
