### PR TITLE
Make use of IMixedRealityBoundaryDataProvider.BoundaryVisibility

### DIFF
--- a/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/Runtime/Providers/BoundarySystem/WindowsMixedRealityBoundaryDataProvider.cs
+++ b/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/Runtime/Providers/BoundarySystem/WindowsMixedRealityBoundaryDataProvider.cs
@@ -8,6 +8,7 @@ using XRTK.Definitions;
 using XRTK.Definitions.Platforms;
 using XRTK.Interfaces.BoundarySystem;
 using XRTK.Services;
+using XRTK.Definitions.BoundarySystem;
 
 #if WINDOWS_UWP
 using System.Linq;
@@ -41,11 +42,7 @@ namespace XRTK.WindowsMixedReality.Providers.BoundarySystem
         #region IMixedRealityBoundaryDataProvider Implementation
 
         /// <inheritdoc />
-        public bool IsPlatformBoundaryVisible
-        {
-            get => false; // TODO Unsure how to currently query the platform for this information.
-            set { }
-        }
+        public BoundaryVisibility Visibility => BoundaryVisibility.Unknown;
 
         /// <inheritdoc />
         public bool IsPlatformConfigured

--- a/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/package.json
+++ b/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/package.json
@@ -10,7 +10,7 @@
     "mixed",
     "reality"
   ],
-  "version": "0.2.6",
+  "version": "0.2.7",
   "unity": "2019.4",
   "license": "MIT",
   "repository": {
@@ -19,7 +19,7 @@
   },
   "author": "XRTK Team (https://github.com/XRTK)",
   "dependencies": {
-    "com.xrtk.core": "0.2.12",
+    "com.xrtk.core": "0.2.12-preview.2",
     "com.unity.xr.windowsmr.metro": "4.2.3"
   },
   "profiles": [

--- a/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/package.json
+++ b/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/package.json
@@ -10,7 +10,7 @@
     "mixed",
     "reality"
   ],
-  "version": "0.2.7",
+  "version": "0.2.6",
   "unity": "2019.4",
   "license": "MIT",
   "repository": {

--- a/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/package.json
+++ b/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/package.json
@@ -10,7 +10,7 @@
     "mixed",
     "reality"
   ],
-  "version": "0.2.6",
+  "version": "0.2.7",
   "unity": "2019.4",
   "license": "MIT",
   "repository": {
@@ -19,7 +19,7 @@
   },
   "author": "XRTK Team (https://github.com/XRTK)",
   "dependencies": {
-    "com.xrtk.core": "0.2.11",
+    "com.xrtk.core": "0.2.12",
     "com.unity.xr.windowsmr.metro": "4.2.3"
   },
   "profiles": [

--- a/XRTK.WindowsMixedReality/Packages/manifest.json
+++ b/XRTK.WindowsMixedReality/Packages/manifest.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.2d.tilemap": "1.0.0",
-    "com.unity.ide.rider": "1.1.4",
+    "com.unity.ide.rider": "1.2.1",
     "com.unity.ide.vscode": "1.2.3",
     "com.unity.test-framework": "1.1.24",
     "com.unity.xr.legacyinputhelpers": "2.1.7",

--- a/XRTK.WindowsMixedReality/Packages/packages-lock.json
+++ b/XRTK.WindowsMixedReality/Packages/packages-lock.json
@@ -20,7 +20,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "1.1.4",
+      "version": "1.2.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -43,15 +43,6 @@
         "com.unity.ext.nunit": "1.0.6",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.textmeshpro": {
-      "version": "2.1.6",
-      "depth": 2,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.ugui": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
@@ -108,7 +99,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.xrtk.core": "0.2.11",
+        "com.xrtk.core": "0.2.12",
         "com.unity.xr.windowsmr.metro": "4.2.3"
       }
     },

--- a/XRTK.WindowsMixedReality/Packages/packages-lock.json
+++ b/XRTK.WindowsMixedReality/Packages/packages-lock.json
@@ -46,6 +46,15 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.textmeshpro": {
+      "version": "2.1.6",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ugui": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.ugui": {
       "version": "1.0.0",
       "depth": 1,
@@ -82,7 +91,7 @@
       "url": "https://packages.unity.com"
     },
     "com.xrtk.core": {
-      "version": "0.2.11",
+      "version": "0.2.12-preview.2",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -99,7 +108,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.xrtk.core": "0.2.12",
+        "com.xrtk.core": "0.2.12-preview.2",
         "com.unity.xr.windowsmr.metro": "4.2.3"
       }
     },


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Updates the WMR boundary data provider to use the new BoundaryVisibility enum. Instead of just saying the boundary is not visible (becuse we can't query it on WMR), we say we simply don't know, which is closer to the thruth.

https://github.com/XRTK/XRTK-Core/pull/822