### PR TITLE
Enable Camera System to work with XR SDK / 2020.1 and above

### DIFF
--- a/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/Profiles~/CameraSystem/WindowsMixedRealityCameraProviderProfile.asset
+++ b/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/Profiles~/CameraSystem/WindowsMixedRealityCameraProviderProfile.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 00d813fd5a164e19a160f322b2926006, type: 3}
   m_Name: WindowsMixedRealityCameraProviderProfile
   m_EditorClassIdentifier: 
+  trackingOriginMode: 1
   isCameraPersistent: 1
   nearClipPlaneOpaqueDisplay: 0.1
   cameraClearFlagsOpaqueDisplay: 1


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

WMR specific changes for https://github.com/XRTK/com.xrtk.core/pull/897.

## Changes

- Updated WMR camera data provider profile to default to tracking space "device", which is the correct setting for HoloLens devices, which are 90% of WMR development target devices

## Related Submodule Changes

- https://github.com/XRTK/com.xrtk.core/pull/897
- https://github.com/XRTK/com.xrtk.lumin/pull/122
- https://github.com/XRTK/com.xrtk.sdk/pull/247
- https://github.com/XRTK/com.xrtk.oculus/pull/134